### PR TITLE
feat: add auto. goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2.9.1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,53 @@
+# Official documentation at http://goreleaser.com
+project_name: githooks
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./
+    binary: githooks
+    goarch:
+      - amd64
+      - arm64
+    goos:
+      - linux
+      - darwin
+      - windows
+    tags:
+      containers_image_openpgp
+    ldflags:
+      - -X github.com/stefan-niemeyer/githooks/version.version={{.Version}}
+      - -X github.com/stefan-niemeyer/githooks/version.gitCommit={{.ShortCommit}}
+      - -w
+      - -s
+dist: bin
+archives:
+  - name_template: "githooks-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    replacements:
+      linux: linux
+      amd64: amd64
+      arm64: arm64
+    files:
+      - none*
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Version }}-next-{{.ShortCommit}}"
+changelog:
+  skip: false
+  sort: asc
+
+nfpms:
+  - file_name_template: "githooks-v{{ .Version }}-{{.Os}}-{{.Arch}}"
+    homepage: https://github.com/stefan-niemeyer/githooks
+    description: "Write something ."
+    maintainer: xiabai84
+    license: None
+    vendor: None
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    replacements:
+      amd64: 64bit
+      arm64: arm64
+      linux: linux

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ githooks cli-tool is a Linux command line application, which is developed with G
 Once it is build, you can launch it directly.
 
 ```shell
-$ curl -fsLO https://github.com/stefan-niemeyer/githooks/raw/main/githooks
+$ curl -sfL https://raw.githubusercontent.com/xiabai84/githooks/main/install.sh | sh
 $ chmod +x githooks
 $ mv githooks /usr/local/bin
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+OSTYPE=""
+ARCH=""
+DOWNLOAD_URL=""
+
+if [ "x${OSTYPE}" = "x" ]; then
+  case $(uname) in
+  "Linux")
+    OSTYPE="linux"
+    ;;
+  "Darwin")
+    OSTYPE="darwin"
+    ;;
+  *)
+    echo 'Warning: Only Linux and MacOS operating systems are currently supported! For Windows-OS,
+    please copy the tar.gz file directly.'
+    exit 1
+    ;;
+  esac
+fi
+
+if [ "x${ARCH}" = "x" ]; then
+  case "$(uname -m)" in
+  x86_64)
+    ARCH=amd64
+    ;;
+  armv8*)
+    ARCH=arm64
+    ;;
+  aarch64*)
+    ARCH=arm64
+    ;;
+  *)
+    echo "${ARCH}, isn't supported"
+    exit 1
+    ;;
+  esac
+fi
+
+if [ "x${DOWNLOAD_URL}" = "x" ]; then
+  DOWNLOAD_URL="$(curl -sL "https://api.github.com/repos/xiabai84/githooks/releases/latest" |
+    grep browser_download_url |
+    cut -d '"' -f 4 |
+    grep "$OSTYPE-$ARCH")"
+fi
+
+filename="${DOWNLOAD_URL##*/}"
+
+echo "Downloading githooks from ${DOWNLOAD_URL} ..."
+
+trap 'rm -f $filename' EXIT
+
+curl -fsLO "$DOWNLOAD_URL"
+
+if [ $? -ne 0 ]; then
+  echo ""
+  echo "Failed to download $filename!"
+  echo ""
+  echo "Please verify the version you are trying to download."
+  echo ""
+  exit
+fi
+
+ret='0'
+command -v tar >/dev/null 2>&1 || { ret='1'; }
+if [ "$ret" -eq 0 ]; then
+  tar -xzf "${filename}"
+  echo "Installation Complete!"
+else
+  echo "$filename Download Complete!"
+  echo ""
+  echo "Try to unpack the ${filename} failed."
+  echo "tar: command not found, please unpack the ${filename} manually."
+  exit 1
+fi


### PR DESCRIPTION
Hi Stefan, 
I've found a tool (goreleaser) for releasing go-applications. 
It requires to configure two configuration-files:
* release.yaml under .github/workflows, which triggers the auto. release.
* .goreleaser.yml  this is the actually release-configurations, for more infos see [http://goreleaser.com]

Once you add a new tag to your project and commit this tag, it will trigger github-actions to publish a new release with this tag.
For example:
```
$ git tag v1.0.0-alpha
$ git push origin --tags
```
For more details see my forked branch: [https://github.com/xiabai84/githooks/releases/tag/v1.0.0-alpha]